### PR TITLE
fix issue compiling "@section('') stuff @show" on one line

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -21,9 +21,9 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		'Includes',
 		'Each',
 		'Yields',
-		'Shows',
 		'SectionStart',
 		'SectionStop',
+		'Shows',
 	);
 
 	/**


### PR DESCRIPTION
Don't know if this is an underlying issue or just to do with compile order but moving 'Shows' below SectionStart fixed an issue I had when doing something like...

`<title>@section('title')SiteName @show</title>`
