### PR TITLE
Enable passing of Traversable Objects to '@each'-structures

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\View;
 
 use Closure;
+use Traversable;
 use Illuminate\Container;
 use Illuminate\Events\Dispatcher;
 use Illuminate\View\Engines\EngineResolver;
@@ -112,19 +113,19 @@ class Environment {
 	 * Get the rendered contents of a partial from a loop.
 	 *
 	 * @param  string  $view
-	 * @param  array   $data
+	 * @param  mixed   $data
 	 * @param  string  $iterator
 	 * @param  string  $empty
 	 * @return string
 	 */
-	public function renderEach($view, array $data, $iterator, $empty = 'raw|')
+	public function renderEach($view, $data, $iterator, $empty = 'raw|')
 	{
 		$result = '';
 
-		// If is actually data in the array, we will loop through the data and append
+		// If there is iterable data, we will loop through the data and append
 		// an instance of the partial view to the final result HTML passing in the
 		// iterated value of this data array, allowing the views to access them.
-		if (count($data) > 0)
+		if ( (is_array($data) || $data instanceof Traversable) && count($data) > 0 )
 		{
 			foreach ($data as $key => $value)
 			{


### PR DESCRIPTION
My suggestion to fix #25, allowing the use of Eloquent Collections when rendering nested Views with @each Structures.

> The renderEach method (View/Environment.php:120) uses an 'array' type-hint for $data, causing type-mismatch issues when passing Eloquent Collections (despite being iterable like an array).

EDIT: Unfortunately, Travis failed to Clone Mockery in the second build job..
