### PR TITLE
add multiple encodings support to echo

### DIFF
--- a/View.php
+++ b/View.php
@@ -9,6 +9,7 @@ use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Contracts\View\Engine;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Support\MessageProvider;
@@ -16,6 +17,10 @@ use Illuminate\Contracts\View\View as ViewContract;
 
 class View implements ArrayAccess, ViewContract
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
     /**
      * The view factory instance.
      *
@@ -395,6 +400,10 @@ class View implements ArrayAccess, ViewContract
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         if (! Str::startsWith($method, 'with')) {
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method


### PR DESCRIPTION
Hey. Faced the problem of output of cp1251 (yes, it is still used) in the output of the echo.
https://github.com/illuminate/view/blob/master/Compilers/Concerns/CompilesEchos.php
89 line, when outputting the escaped variables, the form {{$ var}} - the text disappears.
574 line, function e() - escape only utf-8.
https://github.com/illuminate/support/blob/master/helpers.php
Is it possible to add support for different encodings in the template engine?