### PR TITLE
@error directive with custom bag name

### DIFF
--- a/Compilers/Concerns/CompilesErrors.php
+++ b/Compilers/Concerns/CompilesErrors.php
@@ -15,7 +15,7 @@ trait CompilesErrors
      */
     protected function compileError($expression)
     {
-        i$expression = explode(',', $this->stripParentheses($expression));
+        $expression = explode(',', $this->stripParentheses($expression));
         $bag = Arr::get($expression, 0, 'default');
         $attribute = trim(Arr::get($expression, 1), $expression);
 

--- a/Compilers/Concerns/CompilesErrors.php
+++ b/Compilers/Concerns/CompilesErrors.php
@@ -16,7 +16,7 @@ trait CompilesErrors
     {
         $expression = explode(',', $this->stripParentheses($expression));
         $bag = Arr::get($expression, 0, 'default');
-        $attribute = trim(Arr::get($expression, 1), $expression);
+        $attribute = trim(Arr::get($expression, 1, $expression));
 
         return '<?php if ($errors->getBag('.$bag.')->has('.$attribute.')) :
 if (isset($message)) { $messageCache = $message; }

--- a/Compilers/Concerns/CompilesErrors.php
+++ b/Compilers/Concerns/CompilesErrors.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
 trait CompilesErrors
 {
     /**
@@ -12,11 +15,13 @@ trait CompilesErrors
      */
     protected function compileError($expression)
     {
-        $expression = $this->stripParentheses($expression);
+        i$expression = explode(',', $this->stripParentheses($expression));
+        $bag = Arr::get($expression, 0, 'default');
+        $attribute = trim(Arr::get($expression, 1), $expression);
 
-        return '<?php if ($errors->has('.$expression.')) :
+        return '<?php if ($errors->getBag('.$bag.')->has('.$attribute.')) :
 if (isset($message)) { $messageCache = $message; }
-$message = $errors->first('.$expression.'); ?>';
+$message = $errors->getBag('.$bag.')->first('.$attribute.'); ?>';
     }
 
     /**

--- a/Compilers/Concerns/CompilesErrors.php
+++ b/Compilers/Concerns/CompilesErrors.php
@@ -3,7 +3,6 @@
 namespace Illuminate\View\Compilers\Concerns;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 trait CompilesErrors
 {


### PR DESCRIPTION
I want to use `@error('name')` directive with custom ErrorBag
so I **proposed** defining ErrorBag name by passing 2 parameters to `@error` directive
```
@error('custom_bag`, 'name')
    {{ $message }}
@enderror
```